### PR TITLE
Compute null-safe next water date for plants

### DIFF
--- a/lib/features/plants/owned_plants_screen.dart
+++ b/lib/features/plants/owned_plants_screen.dart
@@ -30,6 +30,11 @@ class OwnedPlantsScreen extends ConsumerWidget {
             separatorBuilder: (_, __) => const Divider(),
             itemBuilder: (ctx, i) {
               final p = plants[i];
+              final nextWater = p.acquiredAt == null
+                  ? null
+                  : p.acquiredAt!
+                      .add(Duration(days: p.customWaterIntervalDays ?? 0))
+                      .toLocal();
               return ListTile(
                 leading: p.photoPath != null
                     ? Image.file(
@@ -41,7 +46,7 @@ class OwnedPlantsScreen extends ConsumerWidget {
                     : const Icon(Icons.local_florist),
                 title: Text(p.nickname ?? p.speciesId),
                 subtitle: Text(
-                  'Next water: ${p.acquiredAt?.add(Duration(days: p.customWaterIntervalDays ?? 0)).toLocal().toString().split(' ').first ?? ''}',
+                  'Next water: ${nextWater?.toString().split(' ').first ?? ''}',
                 ),
                 onTap: () => context.go('/plants/${p.id}'),
               );


### PR DESCRIPTION
## Summary
- Calculate `nextWater` using a null check before building the subtitle
- Show `Next water:` using the computed date without calling methods on null

## Testing
- `flutter format lib/features/plants/owned_plants_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895dd9718908333965a39bc2b3970a4