### PR TITLE
feat: add journal entry deletion from edit screen

### DIFF
--- a/lib/features/journal/add_edit_journal_entry_screen.dart
+++ b/lib/features/journal/add_edit_journal_entry_screen.dart
@@ -51,6 +51,31 @@ class _AddEditJournalEntryScreenState
     if (picked != null) setState(() => _photo = File(picked.path));
   }
 
+  Future<void> _delete() async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete entry?'),
+        content: const Text('This action cannot be undone.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm == true) {
+      await ref.read(journalServiceProvider).deleteEntry(widget.existing!.id);
+      context.go('/journal/${widget.plantId}');
+    }
+  }
+
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) return;
     final svc = ref.read(journalServiceProvider);
@@ -79,7 +104,18 @@ class _AddEditJournalEntryScreenState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(_isEditing ? 'Edit Entry' : 'New Entry')),
+      appBar: AppBar(
+        title: Text(_isEditing ? 'Edit Entry' : 'New Entry'),
+        actions: _isEditing
+            ? [
+                IconButton(
+                  icon: const Icon(Icons.delete),
+                  tooltip: 'Delete Entry',
+                  onPressed: _delete,
+                ),
+              ]
+            : null,
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Form(


### PR DESCRIPTION
## Summary
- allow deleting journal entries from the edit screen with confirmation dialog

## Testing
- `dart format lib/features/journal/add_edit_journal_entry_screen.dart`
- `dart analyze`
- `dart test` *(fails: Because garden_assistant depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available), version solving failed.)*


------
https://chatgpt.com/codex/tasks/task_e_6895fc1abb008333b0eeb0c8899deb43