### PR TITLE
Remove duplicate journal icon from plant detail screen

### DIFF
--- a/lib/features/plants/plant_detail_screen.dart
+++ b/lib/features/plants/plant_detail_screen.dart
@@ -31,15 +31,6 @@ class PlantDetailScreen extends ConsumerWidget {
             leading: BackButton(onPressed: () => context.pop()),
             title: Text(plant.nickname ?? plant.speciesId.capitalize()),
             actions: [
-              // View this plant's journal entries
-              IconButton(
-                icon: const Icon(Icons.book),
-                tooltip: 'View Journal',
-                onPressed: () {
-                  context.go('/journal/${plant.id}');
-                },
-              ),
-
               // Create a new journal entry for this plant
               IconButton(
                 icon: const Icon(Icons.add_comment),


### PR DESCRIPTION
## Summary
- remove top app bar journal icon from plant detail screen since journal link already appears elsewhere

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689603b7771c833399b9aad8dd254cc9